### PR TITLE
Fix overwriting of blok choice in last column

### DIFF
--- a/src/less/columns.less
+++ b/src/less/columns.less
@@ -120,13 +120,13 @@
 
   .blocks-chooser {
     right: 0;
-    left: auto;
+    left: auto !important;
     margin-top: 50px;
   }
 
   .block-toolbar {
     position: absolute;
-    z-index: 3;
+    z-index: 4;
     right: -9px;
     display: flex;
     border: none;


### PR DESCRIPTION
The `left 0` of the `.blocks-chooser` set by Volto had priority over the `left auto` of the volto-columns-block.

fixes #61 

