### PR TITLE
Respects the proportion of columns chosen in Select Layout

### DIFF
--- a/src/ColumnsBlock/ColumnsBlockEdit.jsx
+++ b/src/ColumnsBlock/ColumnsBlockEdit.jsx
@@ -249,7 +249,7 @@ class ColumnsBlockEdit extends React.Component {
     const prevCols = prevProps.data.data?.blocks_layout?.items || [];
 
     const colNumChanged = cols.length !== prevCols.length;
-    const initialLayoutSelection = Object.keys(prevProps.data).length === 1;
+    const initialLayoutSelection = prevCols.length === 0;
     const shouldUpdateLayout = colNumChanged && !initialLayoutSelection;
 
     if (shouldUpdateLayout) {


### PR DESCRIPTION
ColumnsBlockEdit's `componentDidUpdate` method was always setting proportions to the default variation proportions, regardless of the user's choice. That code has been removed, and now the user's choice is respected.

Fixes #57 