### PR TITLE
Refs #285116 - Columns block BlockChooser issues

### DIFF
--- a/src/less/columns.less
+++ b/src/less/columns.less
@@ -113,6 +113,7 @@
   }
 
   .blocks-chooser {
+    position: absolute;
     right: 0;
     left: auto !important;
     margin-top: 50px;


### PR DESCRIPTION
After migrating to Volto 17, the layout of BlockChooser in columns block, is broken. 